### PR TITLE
Add interpellation dates in format recognised by SQLite

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ def main_func():
     # load interpellations and deputies
     loader = InterpellationLoader(
         database_path=config.database['path'],
-        parsed_interpellation_file=config.interpellations['file_path'])
+        parsed_interpellation_file=config.interpellations['path'])
     loader.load_to_database()
 
     # load election districts

--- a/scripts/create_database.sh
+++ b/scripts/create_database.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sqlite3 data/senatores.db < src/sql/create_database.sql

--- a/scripts/delete_data.sh
+++ b/scripts/delete_data.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sqlite3 data/senatores.db < src/sql/delete_data.sql

--- a/scripts/drop_tables.sh
+++ b/scripts/drop_tables.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sqlite3 data/senatores.db < src/sql/drop_tables.sql

--- a/src/CountyLoader.py
+++ b/src/CountyLoader.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import sqlite3
 from typing import List
+from os import path
 
 
 class RawCounty:
@@ -22,8 +23,8 @@ class CountyLoader:
         county_list = None
         try:
             county_list = self.__parse_counties()
-            logging.info('Counties parsed. Counties count: %d',
-                         len(county_list))
+            logging.info('Counties from file %s parsed. Counties count: %d',
+                         path.basename(self.county_file_path_), len(county_list))
         except Exception as e:
             logging.error('Error while parsing county file')
             logging.debug(e, exc_info=True)

--- a/src/CountyLoader.py
+++ b/src/CountyLoader.py
@@ -22,7 +22,7 @@ class CountyLoader:
         county_list = None
         try:
             county_list = self.__parse_counties()
-            logging.info('Counties are parser. Counties count: %d',
+            logging.info('Counties parsed. Counties count: %d',
                          len(county_list))
         except Exception as e:
             logging.error('Error while parsing county file')

--- a/src/ElectionDistrictsLoader.py
+++ b/src/ElectionDistrictsLoader.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 import sqlite3
+from os import path
 from typing import List
 
 
@@ -21,7 +22,7 @@ class ElectionDistrictsLoader:
         try:
             self.districts_ = self.__parse_districts()
             logging.info('Election districts from file %s parsed. Election districts count: %d',
-                         self.districts_file_path_, len(self.districts_))
+                         path.basename(self.districts_file_path_), len(self.districts_))
         except Exception as e:
             logging.error('Error while parsing districts file: %s', self.districts_file_path_)
             logging.debug(e, exc_info=True)

--- a/src/InterpellationLoader.py
+++ b/src/InterpellationLoader.py
@@ -1,6 +1,7 @@
 import sqlite3
-from typing import List, Set
 import logging
+import re
+from typing import List, Set
 from os import path
 
 
@@ -9,6 +10,16 @@ class RawInterpellation:
         self.authors_ = authors
         self.date_ = date.replace('\r\n', '').replace('\n', '')
         self.content_ = content.replace('\r\n', '').replace('\n', '')
+
+
+def to_sqlite_date(raw_date: str):
+    match = re.search(r'(\d\d)-(\d\d)-(\d\d\d\d)', raw_date)
+    if match is None:
+        raise Exception(f'Could not parse interpellation date: {raw_date}')
+    day = match.group(1)
+    month = match.group(2)
+    year = match.group(3)
+    return f'{year}-{month}-{day}'
 
 
 class InterpellationLoader:
@@ -72,7 +83,7 @@ class InterpellationLoader:
 
             for inter in interpellations:
                 cur.execute('INSERT INTO interpellation(date, content) VALUES(?,?)',
-                            (inter.date_, inter.content_))
+                            (to_sqlite_date(inter.date_), inter.content_))
                 inter_id = cur.lastrowid
                 for inter_deputy in inter.authors_:
                     cur.execute('INSERT INTO deputy_interpellation(deputy_id, interpellation_id) VALUES(?,?)',

--- a/src/InterpellationLoader.py
+++ b/src/InterpellationLoader.py
@@ -1,6 +1,7 @@
 import sqlite3
 from typing import List, Set
 import logging
+from os import path
 
 
 class RawInterpellation:
@@ -21,8 +22,8 @@ class InterpellationLoader:
         deputies = None
         try:
             interpellations, deputies = self.__parse_file()
-            logging.info('Interpellations parsed. Interpellations count: %d, deputies count: %d',
-                         len(interpellations), len(deputies))
+            logging.info('Interpellations from file %s parsed. Interpellations count: %d, deputies count: %d',
+                         path.basename(self.interpellation_file_), len(interpellations), len(deputies))
         except Exception as e:
             logging.error('Error while parsing interpellation file')
             logging.debug(e, exc_info=True)

--- a/src/SettleLoader.py
+++ b/src/SettleLoader.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import sqlite3
 from typing import List
+from os import path
 
 
 class RawSettle:
@@ -20,7 +21,8 @@ class SettleLoader:
         settles_list = None
         try:
             settles_list = self.__parse_settles()
-            logging.info('Settles from file %s parsed. Settles count: %d', self.settle_file_path_, len(settles_list))
+            logging.info('Settles from file %s parsed. Settles count: %d', path.basename(self.settle_file_path_),
+                         len(settles_list))
         except Exception as e:
             logging.error('Error while parsing settle file: %s', self.settle_file_path_)
             logging.debug(e, exc_info=True)

--- a/src/VoivodeshipLoader.py
+++ b/src/VoivodeshipLoader.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import sqlite3
 from typing import List
+from os import path
 
 
 class RawVoivodeship:
@@ -19,8 +20,8 @@ class VoivodeshipLoader:
         voivodeship_list = None
         try:
             voivodeship_list = self.__parse_voivodeships()
-            logging.info('Voivodeships parsed. Voivodeships count: %d',
-                         len(voivodeship_list))
+            logging.info('Voivodeships from file %s parsed. Voivodeships count: %d',
+                         path.basename(self.voivodeship_file_path_), len(voivodeship_list))
         except Exception as e:
             logging.error('Error while parsing voivodeships file')
             logging.debug(e, exc_info=True)

--- a/src/VoivodeshipLoader.py
+++ b/src/VoivodeshipLoader.py
@@ -19,7 +19,7 @@ class VoivodeshipLoader:
         voivodeship_list = None
         try:
             voivodeship_list = self.__parse_voivodeships()
-            logging.info('Voivodeships are parser. Voivodeships count: %d',
+            logging.info('Voivodeships parsed. Voivodeships count: %d',
                          len(voivodeship_list))
         except Exception as e:
             logging.error('Error while parsing voivodeships file')

--- a/src/config.py
+++ b/src/config.py
@@ -1,32 +1,36 @@
 import logging
+from os import path
+
+current_file_dir = path.dirname(path.realpath(__file__))
+root_dir = path.abspath(path.join(current_file_dir, ".."))
 
 database = {
-    'path': '/home/krzysztof/PycharmProjects/musarum-res-publicae/data/senatores.db'
+    'path': path.join(root_dir, 'data/senatores.db')
 }
 interpellations = {
-    'file_path': '/home/krzysztof/PycharmProjects/musarum-res-publicae/data/interpelacje-processed.csv'
+    'file_path': path.join(root_dir, 'data/interpelacje-processed.csv')
 }
 logs = {
     'level': logging.DEBUG
 }
 
 voivodeship = {
-    'path': '/home/krzysztof/PycharmProjects/musarum-res-publicae/data/wojewodztwa.csv'
+    'path': path.join(root_dir, 'data/wojewodztwa.csv')
 }
 
 county = {
-    'path': '/home/krzysztof/PycharmProjects/musarum-res-publicae/data/powiaty.csv'
+    'path': path.join(root_dir, 'data/powiaty.csv')
 }
 
 settles = {
-    'dir_path': '/Users/michal/STUDIA/TASS/projekt 2/musarum-res-publica/data/settles',
+    'dir_path': path.join(root_dir, 'data/settles'),
     'files': ['dolnoslaskie.csv', 'krakowskie.csv', 'kujawskie.csv', 'lubelskie.csv', 'lubuskie.csv', 'ludzkie.csv',
               'mazowieckie.csv', 'opolskie.csv', 'podkarpackie.csv', 'podlaskie.csv', 'pomorskie.csv', 'slaskie.csv',
               'swiatokrzyskie.csv', 'vorpommern.csv', 'warminskie.csv', 'wielkopanskie.csv']
 }
 
 election_districts = {
-    'path': '/home/krzysztof/PycharmProjects/musarum-res-publicae/data/okregi_wyborcze.csv'
+    'path': path.join(root_dir, 'data/okregi_wyborcze.csv')
 }
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ database = {
     'path': path.join(root_dir, 'data/senatores.db')
 }
 interpellations = {
-    'file_path': path.join(root_dir, 'data/interpelacje-processed.csv')
+    'path': path.join(root_dir, 'data/interpelacje-processed.csv')
 }
 logs = {
     'level': logging.DEBUG


### PR DESCRIPTION
This PR:
- makes config.py use relative paths so that we won't have to replace them constantly
- cleans up the logging output of main.py
- makes InetrpellationLoader add dates in format recognised by SQLite